### PR TITLE
Fix path issues with the source command referencing content of the script subdirectory

### DIFF
--- a/scripts/conf-db-generic.sh
+++ b/scripts/conf-db-generic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source funs.sh
+source scripts/funs.sh
 
 # The dbupdate script takes care if the DB already exists or creates it
 # otherwise, so wee need the name in any case for the config file:
@@ -14,10 +14,10 @@ if [ $(readkey_choice) == "y" ] ; then
 
     if [ "$dbtype" == "mysql" ];
     then
-        source conf-db-mysql.sh
+        source scripts/conf-db-mysql.sh
     elif [ "$dbtype" == "postgres" ]
     then
-        source conf-db-pgsql.sh
+        source scripts/conf-db-pgsql.sh
     else
         abort "Could not configure database."
     fi

--- a/scripts/conf-hrm.sh
+++ b/scripts/conf-hrm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source funs.sh
+source scripts/funs.sh
 
 # copy config file
 CONF_ETC="/etc/hrm.conf"

--- a/scripts/conf-php.sh
+++ b/scripts/conf-php.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source funs.sh
+source scripts/funs.sh
 
 echo "Enter PHP post_max_size (limits POST size for browser uploads)"
 postmax=`readstring "256M"`

--- a/scripts/inst-hrm.sh
+++ b/scripts/inst-hrm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source funs.sh
+source scripts/funs.sh
 
 echo "Enter the name for a system user for the HRM:"
 hrm_user=`readstring "hrmuser"`
@@ -35,7 +35,7 @@ fi
 
 usermod $apache_user --append --groups $hrm_group
 
-echo "Enter HRM installation directory (must be a sub-directory of Apache document root):"
+echo -e "\nEnter HRM installation directory (must be a sub-directory of Apache document root):"
 hrmdir=`readstring "/var/www/html/hrm"`
 
 # create hrmdir and set permission

--- a/scripts/inst-pkgs.sh
+++ b/scripts/inst-pkgs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source funs.sh
+source scripts/funs.sh
 
 if [ "$dist" == "Ubuntu" ]
 then


### PR DESCRIPTION
since the setup.sh is executed from the root directory of the project, the references made in sources within the scripts directory have to use scripts/[script] that it works during execution.

cosmetics: add a new line in inst-hrm.sh echo command that it does not continue to write on the user input line.